### PR TITLE
touchscreen: fire a small vibration on dt2w

### DIFF
--- a/drivers/input/touchscreen/synaptics_dsx_i2c.c
+++ b/drivers/input/touchscreen/synaptics_dsx_i2c.c
@@ -33,6 +33,7 @@
 #include <asm/uaccess.h>
 #include <mach/device_info.h>
 #include <linux/pcb_version.h>
+#include <linux/qpnp/vibrator.h>
 
 #include "synaptics_dsx.h"
 #include "synaptics_dsx_i2c.h"
@@ -98,6 +99,8 @@ char *tp_firmware_strings[TP_TYPE_MAX][LCD_TYPE_MAX] = {
 #define NO_SLEEP_OFF (0 << 2)
 #define NO_SLEEP_ON (1 << 2)
 #define CONFIGURED (1 << 7)
+
+#define VIBRATE_STRENGTH 27
 
 #ifdef CONFIG_MACH_N3
 static atomic_t key_is_touched;
@@ -2469,7 +2472,10 @@ static unsigned char synaptics_rmi4_update_gesture2(unsigned char *gesture,
 		case SYNA_ONE_FINGER_DOUBLE_TAP:
 			gesturemode = DouTap;
 			if (atomic_read(&syna_rmi4_data->double_tap_enable))
+			{
 				keyvalue = KEY_WAKEUP;
+				vibrate(VIBRATE_STRENGTH);
+			}
 			break;
 
 		case SYNA_ONE_FINGER_DIRECTION:

--- a/drivers/platform/msm/qpnp-vibrator.c
+++ b/drivers/platform/msm/qpnp-vibrator.c
@@ -425,6 +425,11 @@ error_create_level:
 	return rc;
 }
 
+void vibrate(int strength)
+{
+        qpnp_vib_enable(&vib_dev->timed_dev, strength);
+}
+
 static int  __devexit qpnp_vibrator_remove(struct spmi_device *spmi)
 {
 	struct qpnp_vib *vib = dev_get_drvdata(&spmi->dev);

--- a/include/linux/qpnp/vibrator.h
+++ b/include/linux/qpnp/vibrator.h
@@ -36,4 +36,5 @@ static inline int qpnp_vibrator_config(struct qpnp_vib_config *vib_config)
 }
 #endif
 
+void vibrate(int strength);
 #endif /* __QPNP_VIBRATOR_H__ */


### PR DESCRIPTION
- Based on https://github.com/franciscofranco/Shamu/commit/ec81afb3f0c0eed62b3dfd0404731d2898b245fc
- Adapt change for bacon:
  * vib_dev is a static struct that can be used after
     qpnp_vibrator_probe finishes

Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>